### PR TITLE
Use "null" as a signifier of the base unit, like "undefined"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,8 +29,8 @@ converter.convertFrom(2, 'id1') // => 100
 converter.strConvertFrom(5, 'id1') // "250 x lb"
 ```
 
-If you're converting from/to undefined, we assume you're converting from/to the
-base unit (ie, not changing anything):
+If you're converting from/to `undefined` or `null`, we assume you're converting
+from/to the base unit (i.e., not changing anything):
 
 ```javascript
 converter.convertTo(100) // => 100

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ function converter(options) {
   }
 
   function getType(typeId) {
+    if (typeId === null) { typeId = undefined }
     const type = typesById[typeId]
     if(type === undefined) { throw new Error(`${typeId} is not a valid type`) }
     return type

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,16 @@ describe('stateful converters', function() {
       assert.equal(this.converter.strConvertFrom(5, undefined), "5 x lb")
     })
 
+    it('treats a conversion to `null` as converting from the base unit to the base unit', function() {
+      assert.equal(this.converter.convertTo(5, null), 5)
+      assert.equal(this.converter.strConvertTo(5, null), "5 x lb")
+    })
+
+    it('treats a conversion from `null` as converting to the base unit from the base unit', function() {
+      assert.equal(this.converter.convertFrom(5, null), 5)
+      assert.equal(this.converter.strConvertFrom(5, null), "5 x lb")
+    })
+
     it('complains when trying to convert from/to a unit that has not been registered', function() {
       assert.throws(() => this.converter.convertFrom(5, 'not_exist'), /not_exist is not a valid type/)
       assert.throws(() => this.converter.strConvertFrom(5, 'not_exist'), /not_exist is not a valid type/)


### PR DESCRIPTION
Sometimes, you want to intentionally pass around `null` to signify that you're referring to the base unit, instead of just implicitly passing around nothing (`undefined`). Catalytic should support that use case.